### PR TITLE
ui: update the height of value: edit<label> as per the length of string

### DIFF
--- a/phyphox-iOS/phyphox.xcodeproj/project.pbxproj
+++ b/phyphox-iOS/phyphox.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		6BEA94592080B2F30077274A /* MultilineTextElementHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEA94582080B2F30077274A /* MultilineTextElementHandler.swift */; };
 		6BF82BC82147FF6F00175659 /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF82BC72147FF6F00175659 /* SemanticVersion.swift */; };
 		6BFE372C20442AB400301CA3 /* KeyboardTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFE372B20442AB400301CA3 /* KeyboardTracker.swift */; };
+		A1A6A72F297685DF00090309 /* Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A6A72E297685DF00090309 /* Utility.swift */; };
 		C01B1DC721A89E06001FE525 /* ScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01B1DC621A89E06001FE525 /* ScannerViewController.swift */; };
 		C01F80FC226A05C5001B0DF8 /* FormulaAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01F80FB226A05C5001B0DF8 /* FormulaAnalysis.swift */; };
 		C034B0112716F9E500C0EF00 /* ExperimentDepthGUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C034B0102716F9E500C0EF00 /* ExperimentDepthGUIView.swift */; };
@@ -496,6 +497,7 @@
 		6BEA94582080B2F30077274A /* MultilineTextElementHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineTextElementHandler.swift; sourceTree = "<group>"; };
 		6BF82BC72147FF6F00175659 /* SemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersion.swift; sourceTree = "<group>"; };
 		6BFE372B20442AB400301CA3 /* KeyboardTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardTracker.swift; sourceTree = "<group>"; };
+		A1A6A72E297685DF00090309 /* Utility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utility.swift; sourceTree = "<group>"; };
 		C01B1DC621A89E06001FE525 /* ScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerViewController.swift; sourceTree = "<group>"; };
 		C01F80FB226A05C5001B0DF8 /* FormulaAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaAnalysis.swift; sourceTree = "<group>"; };
 		C025FC0623D9D45800AE13B6 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -736,6 +738,7 @@
 				6B7BF7AC1C130457007408FB /* Assets */,
 				6B0C71561C1C708F00500FEE /* Dependencies */,
 				C075DCBD287EA33E001CBE5E /* Settings.bundle */,
+				A1A6A72E297685DF00090309 /* Utility.swift */,
 			);
 			path = phyphox;
 			sourceTree = "<group>";
@@ -1580,6 +1583,7 @@
 				6B7BF7F61C132722007408FB /* ExperimentSensorInput.swift in Sources */,
 				6BE320B21CB3C0DE00DCC1ED /* PTButton.m in Sources */,
 				4B47B0331DA6A87A00CCBA6E /* CountAnalysis.swift in Sources */,
+				A1A6A72F297685DF00090309 /* Utility.swift in Sources */,
 				6B7BF81F1C147CE0007408FB /* DifferentiationAnalysis.swift in Sources */,
 				6B7BF8051C146B23007408FB /* GCDAnalysis.swift in Sources */,
 				6BEA9457207FF8CE0077274A /* GraphViewElementHandler.swift in Sources */,

--- a/phyphox-iOS/phyphox/Info.plist
+++ b/phyphox-iOS/phyphox/Info.plist
@@ -49,7 +49,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>10252</string>
+	<string>10270</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentEditView.swift
+++ b/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentEditView.swift
@@ -32,6 +32,8 @@ final class ExperimentEditView: UIView, DynamicViewModule, DescriptorBoundViewMo
     private let unitLabel: UILabel?
     private let label = UILabel()
     
+    var dynamicLabelHeight = 0.0
+    
     let formatter = NumberFormatter()
 
     required init?(descriptor: EditViewDescriptor) {
@@ -191,6 +193,7 @@ final class ExperimentEditView: UIView, DynamicViewModule, DescriptorBoundViewMo
         textField.text = formattedValue(rawValue)
     }
     
+    
     override func sizeThatFits(_ size: CGSize) -> CGSize {
         //We want to have the gap between label and value centered, so we require atwice the width of the larger half
         let s1 = label.sizeThatFits(size)
@@ -207,11 +210,28 @@ final class ExperimentEditView: UIView, DynamicViewModule, DescriptorBoundViewMo
             right += (spacing+s3.width)
             height = max(height, s3.height)
         }
-        
+
+        dynamicLabelHeight = measureHeightofLabelString(line: label.text ?? "empty") * 2.5
         let width = min(2.0 * max(left, right), size.width)
         
-        return CGSize(width: width, height: height)
+        
+        return CGSize(width: width, height: dynamicLabelHeight)
     }
+    
+    
+    func measureHeightofLabelString(line: String) -> CGFloat {
+        let textView = UITextView()
+        let maxwidth = UIScreen.main.bounds.width
+        textView.frame = CGRect(x:0,y: 0,width: maxwidth,height: CGFloat(MAXFLOAT))
+        textView.textContainerInset = UIEdgeInsets.zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.text = line
+        textView.isScrollEnabled = false
+        textView.sizeToFit()
+        return textView.frame.size.height
+    }
+
     
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -220,7 +240,7 @@ final class ExperimentEditView: UIView, DynamicViewModule, DescriptorBoundViewMo
         let h2 = textField.sizeThatFits(self.bounds.size).height
         let w = (bounds.width - spacing)/2.0
         
-        label.frame = CGRect(origin: CGPoint(x: 0, y: (bounds.height - h)/2.0), size: CGSize(width: w, height: h))
+        label.frame = CGRect(origin: CGPoint(x: 0, y: (bounds.height - dynamicLabelHeight)/2.0), size: CGSize(width: w, height: dynamicLabelHeight))
         
         var actualTextFieldWidth = textFieldWidth
         

--- a/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentEditView.swift
+++ b/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentEditView.swift
@@ -211,7 +211,7 @@ final class ExperimentEditView: UIView, DynamicViewModule, DescriptorBoundViewMo
             height = max(height, s3.height)
         }
 
-        dynamicLabelHeight = Utility.measureHeightofLabelString(line: label.text ?? "-") * 2.5
+        dynamicLabelHeight = Utility.measureHeightofUILabelOnString(line: label.text ?? "-") * 2.5
         let width = min(2.0 * max(left, right), size.width)
         
         

--- a/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentEditView.swift
+++ b/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentEditView.swift
@@ -211,32 +211,17 @@ final class ExperimentEditView: UIView, DynamicViewModule, DescriptorBoundViewMo
             height = max(height, s3.height)
         }
 
-        dynamicLabelHeight = measureHeightofLabelString(line: label.text ?? "empty") * 2.5
+        dynamicLabelHeight = Utility.measureHeightofLabelString(line: label.text ?? "-") * 2.5
         let width = min(2.0 * max(left, right), size.width)
         
         
         return CGSize(width: width, height: dynamicLabelHeight)
-    }
-    
-    
-    func measureHeightofLabelString(line: String) -> CGFloat {
-        let textView = UITextView()
-        let maxwidth = UIScreen.main.bounds.width
-        textView.frame = CGRect(x:0,y: 0,width: maxwidth,height: CGFloat(MAXFLOAT))
-        textView.textContainerInset = UIEdgeInsets.zero
-        textView.textContainer.lineFragmentPadding = 0
-        textView.font = UIFont.preferredFont(forTextStyle: .body)
-        textView.text = line
-        textView.isScrollEnabled = false
-        textView.sizeToFit()
-        return textView.frame.size.height
     }
 
     
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        let h = label.sizeThatFits(self.bounds.size).height
         let h2 = textField.sizeThatFits(self.bounds.size).height
         let w = (bounds.width - spacing)/2.0
         

--- a/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentValueView.swift
+++ b/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentValueView.swift
@@ -124,7 +124,7 @@ final class ExperimentValueView: UIView, DynamicViewModule, DescriptorBoundViewM
         let hangOver = (bounds.width - 2*spacing)/2.0 - s2.width - s3.width - spacing
         let push = hangOver < 0 ? hangOver : 0.0
         
-        dynamicLabelHeight = Utility.measureHeightofLabelString(line: label.text ?? "-") * 2.5
+        dynamicLabelHeight = Utility.measureHeightofUILabelOnString(line: label.text ?? "-") * 2.5
         
         label.frame = CGRect(x: push, y: (bounds.height - dynamicLabelHeight)/2.0, width: bounds.width/2.0 - spacing, height: dynamicLabelHeight)
         valueLabel.frame = CGRect(x: label.frame.maxX + spacing, y: (bounds.height - s2.height)/2.0, width: s2.width, height: s2.height)

--- a/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentValueView.swift
+++ b/phyphox-iOS/phyphox/UI/MainView/ExperimentView/ViewModules/Dynamic/ExperimentValueView.swift
@@ -31,6 +31,8 @@ final class ExperimentValueView: UIView, DynamicViewModule, DescriptorBoundViewM
         }
     }
     
+    var dynamicLabelHeight = 0.0
+    
     required init?(descriptor: ValueViewDescriptor) {
         self.descriptor = descriptor
 
@@ -122,46 +124,12 @@ final class ExperimentValueView: UIView, DynamicViewModule, DescriptorBoundViewM
         let hangOver = (bounds.width - 2*spacing)/2.0 - s2.width - s3.width - spacing
         let push = hangOver < 0 ? hangOver : 0.0
         
-        label.frame = CGRect(x: push, y: (bounds.height - s1.height)/2.0, width: bounds.width/2.0 - spacing, height: s1.height)
+        dynamicLabelHeight = Utility.measureHeightofLabelString(line: label.text ?? "-") * 2.5
+        
+        label.frame = CGRect(x: push, y: (bounds.height - dynamicLabelHeight)/2.0, width: bounds.width/2.0 - spacing, height: dynamicLabelHeight)
         valueLabel.frame = CGRect(x: label.frame.maxX + spacing, y: (bounds.height - s2.height)/2.0, width: s2.width, height: s2.height)
         unitLabel.frame = CGRect(x: valueLabel.frame.maxX, y: (bounds.height - s3.height)/2.0, width: s3.width, height: s3.height)
-
-        fitLabelsOnScreen(_label: s1, _valueLabel: s2, _unitLabel: s3)
-
-    }
-
-    /** Checks which part of the sub screen is out of bound and fix as per the requirement */
-    private func fitLabelsOnScreen(_label: CGSize, _valueLabel: CGSize, _unitLabel: CGSize) {
-
-        let fullScreenWidth = bounds.width
-        let halfScreenWidth = fullScreenWidth/2.0 - spacing
-        let allLabelsWidth = (_label.width + _valueLabel.width + _unitLabel.width )
-        let onlyValUnitWidth = (_valueLabel.width + _unitLabel.width)
-
-        let labelNotInScreenBound : Bool =  halfScreenWidth < _label.width ||  fullScreenWidth < allLabelsWidth
-        let valueNotInScreenBound : Bool = halfScreenWidth < onlyValUnitWidth
-
-        if(labelNotInScreenBound){
-            //Increase height and decrease width and font and set multiline if required
-            label.frame = CGRect(x: 0, y: (bounds.height - _valueLabel.height)/2.0, width: onlyValUnitWidth, height: _valueLabel.height)
-            label.font = UIFont.preferredFont(forTextStyle: .caption1)
-
-            if(labelOutOfBoundDict[label.text!] != nil){
-                labelOutOfBoundDict[label.text!] = true
-            }
-
-        } else if(valueNotInScreenBound){
-            //Decrease width with respect to other labels and decrease font size
-            valueLabel.frame = CGRect(x: label.frame.maxX + spacing, y: (bounds.height - _valueLabel.height)/2.0,
-                    width: fullScreenWidth - _label.width - _unitLabel.width, height: _valueLabel.height)
-            let smallFont = UIFont.preferredFont(forTextStyle: .caption1)
-            valueLabel.font = UIFont.init(descriptor: smallFont.fontDescriptor, size: CGFloat(descriptor.size) * smallFont.pointSize)
-
-        } else {
-            if(labelOutOfBoundDict[label.text!] == false){
-                label.font = UIFont.preferredFont(forTextStyle: .body)
-            }
-        }
+       
     }
 }
 

--- a/phyphox-iOS/phyphox/Utility.swift
+++ b/phyphox-iOS/phyphox/Utility.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class Utility{
     
-    static  func measureHeightofLabelString(line: String) -> CGFloat {
+    static  func measureHeightofUILabelOnString(line: String) -> CGFloat {
         let textView = UITextView()
         let maxwidth = UIScreen.main.bounds.width
         textView.frame = CGRect(x:0,y: 0,width: maxwidth,height: CGFloat(MAXFLOAT))

--- a/phyphox-iOS/phyphox/Utility.swift
+++ b/phyphox-iOS/phyphox/Utility.swift
@@ -1,0 +1,27 @@
+//
+//  Utility.swift
+//  phyphox
+//
+//  Created by Gaurav Tripathee on 17.01.23.
+//  Copyright © 2023 RWTH Aachen. All rights reserved.
+//
+
+import Foundation
+
+class Utility{
+    
+    static  func measureHeightofLabelString(line: String) -> CGFloat {
+        let textView = UITextView()
+        let maxwidth = UIScreen.main.bounds.width
+        textView.frame = CGRect(x:0,y: 0,width: maxwidth,height: CGFloat(MAXFLOAT))
+        textView.textContainerInset = UIEdgeInsets.zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.text = line
+        textView.isScrollEnabled = false
+        textView.sizeToFit()
+        return textView.frame.size.height
+    }
+    
+}
+


### PR DESCRIPTION
This pull request consist of the issue that was discussed in the meeting, where the long string in the value label was not shown completely. Now it measures the height it occupies and maintains the dynamic label height.

Moreover, this pull request consist of the adaptation of the Utility class for ExperimentValueView also. 

I noticed that sometime the size of the label depends upon the <value size="" >, which if placed 1 for long string then the text hides in the UI, so it is better to use size as per the length of the string or not use it at all.