### PR TITLE
Fix UI issues on new experiment sheet

### DIFF
--- a/phyphox-iOS/phyphox/UI/MainView/MenuTableViewController.swift
+++ b/phyphox-iOS/phyphox/UI/MainView/MenuTableViewController.swift
@@ -56,8 +56,9 @@ class MenuTableViewController: UITableViewController {
         let element = elements[indexPath.row]
         
         cell.textLabel?.text = element.label
-        cell.textLabel?.font = UIFont.preferredFont(forTextStyle: .caption1)
         cell.backgroundColor = .clear
+        // Font size adjustment activates ONLY on the original iPhone SE.
+        cell.textLabel?.adjustsFontSizeToFitWidth = true
         cell.separatorInset = .zero
         cell.accessoryView = UIImageView(image: element.icon)
         return cell

--- a/phyphox-iOS/phyphox/UI/MainView/MenuTableViewController.swift
+++ b/phyphox-iOS/phyphox/UI/MainView/MenuTableViewController.swift
@@ -58,6 +58,7 @@ class MenuTableViewController: UITableViewController {
         cell.textLabel?.text = element.label
         cell.textLabel?.font = UIFont.preferredFont(forTextStyle: .caption1)
         cell.backgroundColor = .clear
+        cell.separatorInset = .zero
         cell.accessoryView = UIImageView(image: element.icon)
         return cell
     }
@@ -80,6 +81,11 @@ class MenuTableViewController: UITableViewController {
         tableView.delegate = self
         tableView.backgroundColor = .clear
         tableView.isScrollEnabled = false
+        
+        // Add a separator on the top
+        tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 0.5))
+        tableView.tableHeaderView?.backgroundColor = tableView.separatorColor
+        
         tableView.isUserInteractionEnabled = true
         
         menuAlertController.setValue(self, forKey: "contentViewController")

--- a/phyphox-iOS/phyphox/UI/MainView/MenuTableViewController.swift
+++ b/phyphox-iOS/phyphox/UI/MainView/MenuTableViewController.swift
@@ -33,8 +33,6 @@ class MenuTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        tableView.backgroundColor = UIColor(named: "mainBackground")!
-        
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "menu")
         view.addSubview(tableView)
         
@@ -59,6 +57,7 @@ class MenuTableViewController: UITableViewController {
         
         cell.textLabel?.text = element.label
         cell.textLabel?.font = UIFont.preferredFont(forTextStyle: .caption1)
+        cell.backgroundColor = .clear
         cell.accessoryView = UIImageView(image: element.icon)
         return cell
     }
@@ -79,6 +78,8 @@ class MenuTableViewController: UITableViewController {
         tableView = FixedTableView()
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.backgroundColor = .clear
+        tableView.isScrollEnabled = false
         tableView.isUserInteractionEnabled = true
         
         menuAlertController.setValue(self, forKey: "contentViewController")


### PR DESCRIPTION
Currently, the new experiment action sheet is a little strange. It is partially a blurry material, partially and opaque white background, the wrong font size, and scrollable. It currently looks like this:

![Simulator Screenshot - iPhone 14 Pro Max - 2023-04-20 at 21 40 57](https://user-images.githubusercontent.com/20341514/233521034-30e5278d-2e8d-45d9-95ef-0a44ebb05122.png)

I edited some simple configs to make it look like this instead, much better imitating the native `UIAlert` that this view is supposed to look like: 

![Simulator Screenshot - iPhone 14 Pro Max - 2023-04-20 at 21 39 44](https://user-images.githubusercontent.com/20341514/233521109-23267f85-16fd-4c42-a7d1-99cb2bd57c51.png)

It's still not perfect, but it's much closer to native. The new UI comes with a single drawback: on the _original_ iPhone SE, the "bluetooth" experiment must shrink to fit the width of the container. I figure that since it only affects one rather old phone and that the old UI already didn't look perfect anyway, it's an okay tradeoff to make. If there was an easy, not hackey way to detect the original iPhone SE then I would include a separate, smaller font size for it but I decided against it. 